### PR TITLE
feat: access, refresh token을 위한 keychain 헨들링, 로그인 api 연동

### DIFF
--- a/DrinkingGourmet.xcodeproj/project.pbxproj
+++ b/DrinkingGourmet.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		2E3E5A7F2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */; };
 		2E4CF2A12B7237D20075908C /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 2E4CF2A02B7237D20075908C /* Secret.xcconfig */; };
 		2E56A0DB2B76499A007747ED /* UserInfoDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E56A0DA2B76499A007747ED /* UserInfoDataManager.swift */; };
+		2E56A0DD2B78861B007747ED /* KeyChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E56A0DC2B78861B007747ED /* KeyChain.swift */; };
 		2E6C26C82B497AD200C87B4A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6C26C72B497AD200C87B4A /* AppDelegate.swift */; };
 		2E6C26CA2B497AD200C87B4A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E6C26C92B497AD200C87B4A /* SceneDelegate.swift */; };
 		2E6C26D12B497AD400C87B4A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2E6C26D02B497AD400C87B4A /* Assets.xcassets */; };
@@ -48,6 +49,7 @@
 		2EFA32F72B7156EF00059188 /* RecipeBookCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFA32F62B7156EF00059188 /* RecipeBookCollectionViewCell.swift */; };
 		2EFA32FA2B71629100059188 /* GradientView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFA32F92B71629100059188 /* GradientView.swift */; };
 		2EFA32FD2B71648500059188 /* TodayCombiCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFA32FC2B71648500059188 /* TodayCombiCollectionViewCell.swift */; };
+		2EFF886B2B7BB0E00060C211 /* LoginInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFF886A2B7BB0E00060C211 /* LoginInfoModel.swift */; };
 		5658DDF72B57498600F72F42 /* TodayCombinationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5658DDF62B57498600F72F42 /* TodayCombinationViewController.swift */; };
 		5658DDF92B57C2A200F72F42 /* TodayCombinationCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5658DDF82B57C2A200F72F42 /* TodayCombinationCell.swift */; };
 		5658DE002B582A8D00F72F42 /* TodayCombinationDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5658DDFF2B582A8D00F72F42 /* TodayCombinationDetailViewController.swift */; };
@@ -115,6 +117,7 @@
 		2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadedImgCollectionViewCell.swift; sourceTree = "<group>"; };
 		2E4CF2A02B7237D20075908C /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		2E56A0DA2B76499A007747ED /* UserInfoDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoDataManager.swift; sourceTree = "<group>"; };
+		2E56A0DC2B78861B007747ED /* KeyChain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyChain.swift; sourceTree = "<group>"; };
 		2E6C26C42B497AD200C87B4A /* DrinkingGourmet.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DrinkingGourmet.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E6C26C72B497AD200C87B4A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		2E6C26C92B497AD200C87B4A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -143,6 +146,7 @@
 		2EFA32F62B7156EF00059188 /* RecipeBookCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeBookCollectionViewCell.swift; sourceTree = "<group>"; };
 		2EFA32F92B71629100059188 /* GradientView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradientView.swift; sourceTree = "<group>"; };
 		2EFA32FC2B71648500059188 /* TodayCombiCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCombiCollectionViewCell.swift; sourceTree = "<group>"; };
+		2EFF886A2B7BB0E00060C211 /* LoginInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginInfoModel.swift; sourceTree = "<group>"; };
 		5658DDF62B57498600F72F42 /* TodayCombinationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCombinationViewController.swift; sourceTree = "<group>"; };
 		5658DDF82B57C2A200F72F42 /* TodayCombinationCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCombinationCell.swift; sourceTree = "<group>"; };
 		5658DDFF2B582A8D00F72F42 /* TodayCombinationDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCombinationDetailViewController.swift; sourceTree = "<group>"; };
@@ -253,6 +257,7 @@
 			isa = PBXGroup;
 			children = (
 				2E1D4F072B72816A0065D9B2 /* UserInfoModel.swift */,
+				2EFF886A2B7BB0E00060C211 /* LoginInfoModel.swift */,
 				2E56A0DA2B76499A007747ED /* UserInfoDataManager.swift */,
 			);
 			path = Model;
@@ -477,6 +482,7 @@
 		2EB001902B5E40A400B74580 /* UserAuthentication */ = {
 			isa = PBXGroup;
 			children = (
+				2E56A0DC2B78861B007747ED /* KeyChain.swift */,
 				2EE2E88C2B657A52006F81E9 /* KakaoAuthViewModel.swift */,
 				2E0274E52B6FEF3E00F92177 /* UserDefaultManager.swift */,
 				2E1D4F062B72813B0065D9B2 /* Model */,
@@ -948,12 +954,14 @@
 				2EE2E88D2B657A52006F81E9 /* KakaoAuthViewModel.swift in Sources */,
 				5668A34D2B6FBAF00009FCD6 /* RecipeBookDetailVC.swift in Sources */,
 				2E56A0DB2B76499A007747ED /* UserInfoDataManager.swift in Sources */,
+				2E56A0DD2B78861B007747ED /* KeyChain.swift in Sources */,
 				5668A2EF2B6EDB4F0009FCD6 /* CustomResultSearchBar.swift in Sources */,
 				5668A2FB2B6EDCCC0009FCD6 /* CommunityHomeDataManager.swift in Sources */,
 				56A9A93E2B6B52FE00EF7CA6 /* CommentsView.swift in Sources */,
 				5668A2EB2B6EDB340009FCD6 /* SearchResultCell.swift in Sources */,
 				2EFA32F02B714B6200059188 /* UILabel + setLineSpacing.swift in Sources */,
 				2EFA32EE2B71153500059188 /* MainMenuBannerCollectionViewCell.swift in Sources */,
+				2EFF886B2B7BB0E00060C211 /* LoginInfoModel.swift in Sources */,
 				2E6C26CA2B497AD200C87B4A /* SceneDelegate.swift in Sources */,
 				5668A3D12B78F69C0009FCD6 /* CombinationSearchVC.swift in Sources */,
 				97EB4AFC2B720D42009A62EB /* LoadingRecommendDrinkViewController.swift in Sources */,

--- a/DrinkingGourmet/App/SceneDelegate.swift
+++ b/DrinkingGourmet/App/SceneDelegate.swift
@@ -12,42 +12,30 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-//
-//    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-//            guard let windowScene = (scene as? UIWindowScene) else { return }
-//            
-//            let window = UIWindow(windowScene: windowScene)
-//            
-//            let rootViewController = AuthenticationViewController()
-//            let navigationController = UINavigationController(rootViewController: rootViewController)
-//        
-//            window.rootViewController = navigationController
-//            window.makeKeyAndVisible()
-//            
-//            self.window = window
-//        }
-//    
-//    
-    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
 
         let window = UIWindow(windowScene: windowScene)
         self.window = window
 
-        let isLoggedIn = UserDefaults.standard.bool(forKey: "isLoggedIn")
-
-        if isLoggedIn {
-            window.rootViewController = UINavigationController(rootViewController: MainMenuViewController())
-        } else {
+        do {
+            let refreshToken = try Keychain.shared.getToken(kind: .refreshToken)
+            print("Refresh Token: \(refreshToken)")
+            UserInfoDataManager.shared.loginWithProviderInfo { [weak self] in
+                        DispatchQueue.main.async {
+                            self?.window?.rootViewController = UINavigationController(rootViewController: MainMenuViewController())
+                            self?.window?.makeKeyAndVisible()
+                        }
+                    }
+//            window.rootViewController = UINavigationController(rootViewController: MainMenuViewController())
+        } catch {
+            print("Refresh Token not found")
             window.rootViewController = UINavigationController(rootViewController: AuthenticationViewController())
         }
 
         window.makeKeyAndVisible()
     }
 
-
-    
     func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
         if let url = URLContexts.first?.url {
             if (AuthApi.isKakaoTalkLoginUrl(url)) {

--- a/DrinkingGourmet/Info.plist
+++ b/DrinkingGourmet/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>KAKAO_APP_KEY</key>
-	<string>${KAKAO_API_KEY}</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -11,14 +9,33 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>kakao${KAKAO_APP_KEY}</string>
+				<string>kakao${KAKAO_API_KEY}</string>
 			</array>
 		</dict>
+	</array>
+	<key>KAKAO_APP_KEY</key>
+	<string>${KAKAO_API_KEY}</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaolink</string>
 	</array>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>
 		<false/>
+		<key>NSExceptionDomains</key>
+		<dict>
+			<key>drink-gourmet.kro.kr</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+				<key>NSTemporaryExceptionMinimumTLSVersion</key>
+				<string>TLSv1.1</string>
+			</dict>
+		</dict>
 	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
@@ -37,10 +54,5 @@
 			</array>
 		</dict>
 	</dict>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>kakaokompassauth</string>
-		<string>kakaolink</string>
-	</array>
 </dict>
 </plist>

--- a/DrinkingGourmet/Source/UserAuthentication/KakaoAuthViewModel.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/KakaoAuthViewModel.swift
@@ -15,14 +15,12 @@ class KakaoAuthViewModel: ObservableObject {
     var subscriptions = Set<AnyCancellable>()
     
     // 로그인 여부를 저장
-        @Published var isLoggedIn: Bool = false
+    @Published var isLoggedIn: Bool = false
     // 사용자 정보를 저장
     @Published var userInfo: User? = nil
     
-    lazy var loginStatusInfo: AnyPublisher<String?, Never> = $isLoggedIn.compactMap { $0 ? "로그인 상태" : "로그아웃 상태" }.eraseToAnyPublisher()
-    
     init() {
-        print("kakaoauthVM - init")
+        
     }
     
     @MainActor  // 내부적으로 UI를 건드나 싶어서 추가
@@ -59,7 +57,7 @@ class KakaoAuthViewModel: ObservableObject {
                 }
                 else {
                     print("loginWithKakaoAccount() success.")
-//                    print(oauthToken)
+                    
                     _ = oauthToken
                     
                     Task {
@@ -74,55 +72,26 @@ class KakaoAuthViewModel: ObservableObject {
     }
     
     @MainActor
-        func checkTokenValidity() async -> Bool {    // 토큰 유효성 체크
-           await withCheckedContinuation { continuation in
-               if (AuthApi.hasToken()) {
-                   UserApi.shared.accessTokenInfo { (_, error) in
-                       if let error = error {
-                           if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
-                               continuation.resume(returning: false)
-                           } else {
-                               continuation.resume(returning: false)
-                           }
-                       } else {
-                           print("Token is valid.")
-                           continuation.resume(returning: true)
-                       }
-                   }
-               } else {
-                   continuation.resume(returning: false)
-               }
-           }
+    func checkTokenValidity() async -> Bool {    // 토큰 유효성 체크
+        await withCheckedContinuation { continuation in
+            if (AuthApi.hasToken()) {
+                UserApi.shared.accessTokenInfo { (_, error) in
+                    if let error = error {
+                        if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
+                            continuation.resume(returning: false)
+                        } else {
+                            continuation.resume(returning: false)
+                        }
+                    } else {
+                        print("Token is valid.")
+                        continuation.resume(returning: true)
+                    }
+                }
+            } else {
+                continuation.resume(returning: false)
+            }
         }
-    
-//    func checkTokenValidity() -> Bool {
-//        let group = DispatchGroup()
-//        var result = false
-//
-//        group.enter()
-//        if (AuthApi.hasToken()) {
-//            UserApi.shared.accessTokenInfo { (_, error) in
-//                if let error = error {
-//                    if let sdkError = error as? SdkError, sdkError.isInvalidTokenError() == true {
-//                        result = false
-//                    } else {
-//                        result = false
-//                    }
-//                } else {
-//                    print("Token is valid.")
-//                    result = true
-//                }
-//                group.leave()
-//            }
-//        } else {
-//            result = false
-//            group.leave()
-//        }
-//
-//        group.wait()
-//        return result
-//    }
-
+    }
         
         @MainActor
         func kakaoLogin() {
@@ -140,28 +109,28 @@ class KakaoAuthViewModel: ObservableObject {
             }
         }
     
-//    @MainActor
-//        func kakaoLoginWithAccountPrompt() async -> Bool {  // 간편 로그인
-//            await withCheckedContinuation { continuation in
-//                UserApi.shared.loginWithKakaoAccount(prompts:[.SelectAccount]) {(oauthToken, error) in
-//                    if let error = error {
-//                        print(error)
-//                        continuation.resume(returning: false)
-//                    }
-//                    else {
-//                        print("loginWithKakaoAccount() success.")
-//                        
-//                        _ = oauthToken
-//                        
-//                        Task {
-//                            await self.setUserInfo()
-//                        }
-//                        
-//                        continuation.resume(returning: true)
-//                    }
-//                }
-//            }
-//        }
+    @MainActor
+        func kakaoLoginWithAccountPrompt() async -> Bool {  // 간편 로그인
+            await withCheckedContinuation { continuation in
+                UserApi.shared.loginWithKakaoAccount(prompts:[.SelectAccount]) {(oauthToken, error) in
+                    if let error = error {
+                        print(error)
+                        continuation.resume(returning: false)
+                    }
+                    else {
+                        print("loginWithKakaoAccount() success.")
+                        
+                        _ = oauthToken
+                        
+                        Task {
+                            await self.setUserInfo()
+                        }
+                        
+                        continuation.resume(returning: true)
+                    }
+                }
+            }
+        }
     
     @MainActor
     func kakaoLogut() {
@@ -196,7 +165,6 @@ class KakaoAuthViewModel: ObservableObject {
                     continuation.resume(returning: ())
                 }
                 else {
-                    print("me() success.")
                     self.userInfo = user
                     continuation.resume(returning: ())
                 }

--- a/DrinkingGourmet/Source/UserAuthentication/KeyChain.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/KeyChain.swift
@@ -1,0 +1,76 @@
+//
+//  KeyChain.swift
+//  DrinkingGourmet
+//
+//  Created by hwijinjeong on 2/11/24.
+//
+
+import Security
+import Foundation
+
+enum KeyChainError: Error {
+    case noData
+    case unexpectedData
+    case unhandledError(status: OSStatus)
+}
+
+class Keychain {
+    static let shared = Keychain()
+    
+    enum TokenKind: String {
+        case accessToken = "Authorization"
+        case refreshToken = "RefreshToken"
+    }
+    
+    private init() { }
+    
+    func saveToken(kind: TokenKind, token: String) {
+        guard let data = token.data(using: .utf8) else { return }
+
+        let query = [
+            kSecClass as String       : kSecClassGenericPassword,
+            kSecAttrAccount as String : kind.rawValue,
+            kSecValueData as String   : data ] as [String : Any]
+        
+        // 기존에 있던 건 업데이트
+        let status = SecItemUpdate(query as CFDictionary, [kSecValueData as String: data] as CFDictionary)
+
+        if status == errSecItemNotFound {
+            // 기존에 없던 건 추가
+            SecItemAdd(query as CFDictionary, nil)
+        } else if status != errSecSuccess {
+            print("Failed to save token: \(status)")
+        }
+    }
+
+    
+    func getToken(kind: TokenKind) throws -> String {
+        let query = [
+            kSecClass as String       : kSecClassGenericPassword,
+            kSecAttrAccount as String : kind.rawValue,
+            kSecReturnData as String  : kCFBooleanTrue!,
+            kSecMatchLimit as String  : kSecMatchLimitOne ] as [String : Any]
+
+        var dataTypeRef: AnyObject?
+        let status: OSStatus = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+        
+        guard status != errSecItemNotFound else { throw KeyChainError.noData }
+        guard status == errSecSuccess else { throw KeyChainError.unhandledError(status: status) }
+        
+        guard let data = dataTypeRef as? Data, let token = String(data: data, encoding: .utf8) else {
+            throw KeyChainError.unexpectedData
+        }
+        
+        return token
+    }
+    
+    func deleteToken(kind: TokenKind) throws {
+        let query = [
+            kSecClass as String       : kSecClassGenericPassword,
+            kSecAttrAccount as String : kind.rawValue
+        ] as [String : Any]
+
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else { throw KeyChainError.unhandledError(status: status) }
+    }
+}

--- a/DrinkingGourmet/Source/UserAuthentication/Model/LoginInfoModel.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Model/LoginInfoModel.swift
@@ -1,0 +1,13 @@
+//
+//  LoginInfoModel.swift
+//  DrinkingGourmet
+//
+//  Created by hwijinjeong on 2/13/24.
+//
+
+import Foundation
+
+struct LoginInfoModel: Encodable {
+    var provider: String
+    var providerId: String
+}

--- a/DrinkingGourmet/Source/UserAuthentication/Model/UserInfoDataManager.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Model/UserInfoDataManager.swift
@@ -5,6 +5,7 @@
 //  Created by hwijinjeong on 2/9/24.
 //
 
+import Foundation
 import Alamofire
 
 class UserInfoDataManager {
@@ -12,25 +13,80 @@ class UserInfoDataManager {
     
     private init() { }
     
-    func sendUserInfo(_ parameter: UserInfoModel) {
-            let headers: HTTPHeaders = [
-                "Content-Type": "application/json"
-            ]
-            
-            AF.request("https://drink-gourmet.kro.kr/auth/kakao",
-                       method: .post,
-                       parameters: parameter,
-                       encoder: JSONParameterEncoder.default,
-                       headers: headers)
-                .validate()
-                .response { response in
-                    switch response.result {
-                    case .success:
-                        print("Request Successful")
-                    case .failure(let failure):
-                        print("Request Failed: \(failure)")
+    func sendUserInfo(_ parameter: UserInfoModel, completion: @escaping () -> Void) {
+        print("sendUserInfo providerId: \(UserDefaultManager.shared.providerId)")
+        let headers: HTTPHeaders = ["Content-Type": "application/json"]
+        
+        AF.request("https://drink-gourmet.kro.kr/auth/kakao",
+                   method: .post,
+                   parameters: parameter,
+                   encoder: JSONParameterEncoder.default,
+                   headers: headers)
+        .validate()
+        .response { response in
+            switch response.result {
+            case .success:
+                if let headerFields = response.response?.allHeaderFields as? [String: String],
+                    let url = response.request?.url {
+                    if let refreshToken = headerFields["RefreshToken"] {
+                        Keychain.shared.saveToken(kind: .refreshToken, token: refreshToken)
+                        print("Saved Refresh Token: \(refreshToken)")
+                    }
+                        
+                    if let accessToken = headerFields["Authorization"] {
+                        Keychain.shared.saveToken(kind: .accessToken, token: accessToken)
+                        print("Saved Access Token: \(accessToken)")
+                        completion()
                     }
                 }
+            case .failure(let failure):
+                print("Request Failed: \(failure)")
+            }
         }
-}
+    }
+    
+    func loginWithProviderInfo(completion: @escaping () -> Void) {
+        print("loginWithProviderInfo providerId: \(UserDefaultManager.shared.providerId)")
+        // provider와 providerId를 UserDefaults에서 가져옵니다.
+        let provider = UserDefaultManager.shared.provider
+        let providerId = UserDefaultManager.shared.providerId
+        
+        // 로그인에 필요한 정보를 모델로 만듭니다.
+        let loginInfo = LoginInfoModel(provider: provider, providerId: providerId)
+        
+        let headers: HTTPHeaders = ["Content-Type": "application/json"]
+        
+        AF.request("https://drink-gourmet.kro.kr/auth/kakao",
+                   method: .post,
+                   parameters: loginInfo,
+                   encoder: JSONParameterEncoder.default,
+                   headers: headers)
+        .validate(statusCode: 200..<601)
+        .response { response in
+            switch response.result {
+            case .success:
+                if let headerFields = response.response?.allHeaderFields as? [String: String],
+                    let url = response.request?.url {
+                    if let refreshToken = headerFields["RefreshToken"] {
+                        Keychain.shared.saveToken(kind: .refreshToken, token: refreshToken)
+                        print("Saved Refresh Token: \(refreshToken)")
+                    }
+                        
+                    if let accessToken = headerFields["Authorization"] {
+                        Keychain.shared.saveToken(kind: .accessToken, token: accessToken)
+                        print("Saved Access Token: \(accessToken)")
+                        completion()
+                    }
+                }
+                
+                if let data = response.data, let str = String(data: data, encoding: .utf8) {
+                    print("Server Response: \(str)")
+                    print(UserDefaultManager.shared.userGender)
+                }
+            case .failure(let failure):
+                print("Request Failed: \(failure)")
+            }
+        }
+    }
 
+}

--- a/DrinkingGourmet/Source/UserAuthentication/Model/UserInfoModel.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Model/UserInfoModel.swift
@@ -5,6 +5,8 @@
 //  Created by hwijinjeong on 2/7/24.
 //
 
+import Foundation
+
 struct UserInfoModel: Encodable {
     var name: String
     var profileImage: String

--- a/DrinkingGourmet/Source/UserAuthentication/UserDefaultManager.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/UserDefaultManager.swift
@@ -24,7 +24,6 @@ class UserDefaultManager {
         case email
         case provider
         case providerId
-        case isLoggedIn
     }
     
     let ud = UserDefaults.standard
@@ -108,18 +107,5 @@ class UserDefaultManager {
         set {
             ud.setValue(newValue, forKey: UDKey.providerId.rawValue)
         }
-    }
-    
-    var isLoggedIn: Bool {
-        get {
-            ud.bool(forKey: UDKey.isLoggedIn.rawValue)
-        }
-        set {
-            ud.setValue(newValue, forKey: UDKey.isLoggedIn.rawValue)
-        }
-    }
-
-    func removeAll() {
-        
     }
 }

--- a/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/TermsViewController.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/TermsViewController.swift
@@ -157,8 +157,6 @@ extension TermsViewController {
     
     @objc func btnClicked(sender: UIButton) {
         if sender.isSelected == true {
-            print("이미 선택되어있던 걸 클릭")
-                
             sender.buttonConfiguration(
             title: buttonDictionary[sender] ?? "",
             font: .systemFont(ofSize: 14),
@@ -169,8 +167,6 @@ extension TermsViewController {
             )
             sender.isSelected = false
         } else {
-            print("그 외를 클릭")
-            print(buttonDictionary[sender] ?? "")
             sender.buttonConfiguration(
             title: buttonDictionary[sender] ?? "",
             font: .systemFont(ofSize: 14),
@@ -237,7 +233,6 @@ extension TermsViewController {
                 imageSize: CGSize(width: 23, height: 20)
             )
             totalTermsBtn.isSelected = false
-            print("totaltermsbtn이 false")
         } else {
             totalTermsBtn.buttonConfiguration(
                 title: "전체 약관에 동의합니다.",

--- a/DrinkingGourmet/Util/Extension/UIButton+Configuration.swift
+++ b/DrinkingGourmet/Util/Extension/UIButton+Configuration.swift
@@ -85,4 +85,18 @@ extension UIButton {
         self.configuration = config
         self.layer.cornerRadius = 8
     }
+    
+    func logoutBtnConfig(title: String, font: UIFont, backgroundColor: UIColor) {
+        var config = UIButton.Configuration.plain()
+        
+        var titleAttr = AttributedString.init(title)
+        titleAttr.foregroundColor = .darkGray
+        titleAttr.font = font
+        
+        config.attributedTitle = titleAttr
+        config.baseForegroundColor = .white
+        
+        self.backgroundColor = backgroundColor
+        self.configuration = config
+    }
 }

--- a/DrinkingGourmet/Util/InputTextField/InputTextFieldView.swift
+++ b/DrinkingGourmet/Util/InputTextField/InputTextFieldView.swift
@@ -47,7 +47,6 @@ class InputTextFieldView: UIView {
     
     @objc func textFieldDidChange(_ textField: UITextField) {
         guard let text = textField.text else { return }
-        print("\(text)입니다")
 
         // 콜백 클로저 호출
         onTextChanged?(text)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
[o] 기능 추가<br>
[] 기능 삭제<br>
[] 버그 수정<br>
[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>
## 반영 브랜치
feat/token-management -> main

<br>

## 변경 사항
access token과 refresh token을 관리할 수 있는 keychain 헨들링을 추가했습니다.
토큰 유무에 따라 앱 시작 화면을 다르게 하였으며
로그인일 경우 따로 api 연동하였습니다.
<br>

## 스크린샷(선택사항)
