### PR TITLE
Feat: 오늘의 조합 댓글 구현 (대댓글 구현 전)

### DIFF
--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentInput.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentInput.swift
@@ -5,6 +5,14 @@
 //  Created by 이승민 on 2/14/24.
 //
 
-struct CombinationCommentInput: Codable {
-    var page: Int?
+struct CombinationCommentInput {
+    
+    struct fetchCombinatiCommentDataInput: Codable {
+        let page: Int?
+    }
+    
+    struct postCommentInput: Codable {
+        let content: String
+        let parentId: String
+    }
 }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentInput.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentInput.swift
@@ -5,7 +5,6 @@
 //  Created by 이승민 on 2/14/24.
 //
 
-// MARK: - 오늘의 조합 상세보기 댓글 페이징 조회 Query Prams
 struct CombinationCommentInput: Codable {
     var page: Int?
 }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentModel.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationCommentModel.swift
@@ -5,7 +5,6 @@
 //  Created by 이승민 on 2/14/24.
 //
 
-// MARK: - 오늘의 조합 상세보기 댓글 페이징 조회 Model
 struct CombinationCommentModel: Codable {
     let isSuccess: Bool
     let code, message: String
@@ -19,7 +18,9 @@ struct CombinationCommentModel: Codable {
     
     struct CombinationCommentList: Codable {
         let id: Int
-        let content, memberName, updatedAt: String
+        let content, memberNickName: String
+        let memberProfile: String?
+        let updatedAt: String
         let childCount: Int
         let childComments: [CombinationCommentList]
     }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
@@ -42,10 +42,10 @@ class CombinationDetailDataManager {
     }
     
     // MARK: - 오늘의 조합 댓글 페이징 조회
-    func fetchCombinatiCommentData(_ combinationID: Int,
-                                   _ parameters: CombinationCommentInput,
-                                   _ viewController: TodayCombinationDetailViewController,
-                                   completion: @escaping (CombinationCommentModel?) -> Void) {
+    func fetchCombinatiCommentData (_ combinationID: Int,
+                                    _ parameters: CombinationCommentInput.fetchCombinatiCommentDataInput,
+                                    _ viewController: TodayCombinationDetailViewController,
+                                    completion: @escaping (CombinationCommentModel?) -> Void) {
         
         AF.request("\(baseURL)/combination-comments/\(combinationID)",
                    method: .get,
@@ -60,6 +60,34 @@ class CombinationDetailDataManager {
                 print("오늘의 조합 댓글 페이징 조회 - \(error)")
                 completion(nil)
             }
+        }
+    }
+
+    // MARK: - 오늘의 조합 댓글 작성
+    func postComment (_ combinationID: Int,
+                      _ parameters: CombinationCommentInput.postCommentInput) {
+        do {
+            let accessToken = try Keychain.shared.getToken(kind: .accessToken)
+            
+            let headers: HTTPHeaders = [
+                "Authorization": "Bearer \(accessToken)"
+            ]
+            
+            AF.request("\(baseURL)/combination-comments/\(combinationID)",
+                       method: .post,
+                       parameters: parameters,
+                       encoder: JSONParameterEncoder.default,
+                       headers: headers).responseJSON { response in
+                switch response.result {
+                case .success(let value):
+//                    print("Response: \(value)")
+                    print("댓글 작성 성공")
+                case .failure(let error):
+                    print("Error: \(error)")
+                }
+            }
+        } catch {
+            print("Failed to get access token")
         }
     }
     

--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
@@ -10,36 +10,57 @@ import Alamofire
 class CombinationDetailDataManager {
     
     private let baseURL = "https://drink-gourmet.kro.kr"
-    private let testAcessToken: HTTPHeaders = [
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYWthb18xMjM0NTY3ODkiLCJpYXQiOjE3MDc4MTY0OTQsImV4cCI6MTcwODQyMTI5NH0.tL3VWPK1W_3IR3_eIyOS0Lmn1qNTnfKRcb-nkNU7Glo"
-    ]
     
-    // MARK: - 오늘의 조합 상세보기 조회
-    func fetchCombinationDetailData(_ combinationID: Int, _ viewController: TodayCombinationDetailViewController, completion: @escaping (CombinationDetailModel?) -> Void) {
-
-        AF.request("\(baseURL)/combinations/\(combinationID)", method: .get, headers: testAcessToken).validate().responseDecodable(of: CombinationDetailModel.self) { response in
+    // MARK: - 오늘의 조합 상세정보 조회
+    func fetchCombinationDetailData (_ combinationID: Int,
+                                     _ viewController: TodayCombinationDetailViewController,
+                                     completion: @escaping (CombinationDetailModel?) -> Void) {
+        do {
+            let accessToken = try Keychain.shared.getToken(kind: .accessToken)
+            
+            let headers: HTTPHeaders = [
+                "Authorization": "Bearer \(accessToken)"
+            ]
+            
+            AF.request("\(baseURL)/combinations/\(combinationID)",
+                       method: .get,
+                       headers: headers)
+            .validate()
+            .responseDecodable(of: CombinationDetailModel.self) { response in
+                switch response.result {
+                case .success(let result):
+                    print("오늘의 조합 상세정보 조회 - 네트워킹 성공")
+                    completion(result)
+                case .failure(let error):
+                    print("오늘의 조합 상세정보 조회 - \(error)")
+                    completion(nil)
+                }
+            }
+        } catch {
+            print("Failed to get access token")
+        }
+    }
+    
+    // MARK: - 오늘의 조합 댓글 페이징 조회
+    func fetchCombinatiCommentData(_ combinationID: Int,
+                                   _ parameters: CombinationCommentInput,
+                                   _ viewController: TodayCombinationDetailViewController,
+                                   completion: @escaping (CombinationCommentModel?) -> Void) {
+        
+        AF.request("\(baseURL)/combination-comments/\(combinationID)",
+                   method: .get,
+                   parameters: parameters)
+        .validate()
+        .responseDecodable(of: CombinationCommentModel.self) { response in
             switch response.result {
             case .success(let result):
-                print("오늘의 조합 상세정보 조회 - 네트워킹 성공")
+                print("오늘의 조합 댓글 페이징 조회 - 네트워킹 성공")
                 completion(result)
             case .failure(let error):
-                print("오늘의 조합 상세정보 조회 - \(error)")
+                print("오늘의 조합 댓글 페이징 조회 - \(error)")
                 completion(nil)
             }
         }
     }
     
-    // MARK: - 오늘의 조합 상세보기 댓글 페이징 조회
-    func fetchCombinatiCommentData(_ combinationID: Int, _ parameters: CombinationCommentInput, _ viewController: TodayCombinationDetailViewController, completion: @escaping (CombinationCommentModel?) -> Void) {
-        AF.request("\(baseURL)/combination-comments/\(combinationID)", method: .get, parameters: parameters).validate().responseDecodable(of: CombinationCommentModel.self) { response in
-            switch response.result {
-            case .success(let result):
-                print("오늘의조합 댓글 조회 - 네트워킹 성공")
-                completion(result)
-            case .failure(let error):
-                print("오늘의조합 댓글 조회 - \(error)")
-                completion(nil)
-            }
-        }
-    }
 }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailModel.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailModel.swift
@@ -5,7 +5,6 @@
 //  Created by 이승민 on 2/14/24.
 //
 
-// MARK: - 오늘의 조합 상세보기 조회 Model
 struct CombinationDetailModel: Codable {
     let isSuccess: Bool
     let code, message: String
@@ -16,41 +15,34 @@ struct CombinationDetailModel: Codable {
         let memberResult: MemberResult
         let combinationCommentResult: CombinationCommentResult
     }
-
+    
     struct CombinationCommentResult: Codable {
         let combinationCommentList: [CombinationCommentList]
         let listSize, totalPage, totalElements: Int
         let isFirst, isLast: Bool
     }
-
+    
     struct CombinationCommentList: Codable {
         let id: Int
-        let content, memberName, updatedAt: String
+        let content: String
+        let memberNickName: String
+        let memberProfile: String?
+        let updatedAt: String
         let childCount: Int
         let childComments: [CombinationCommentList]
     }
-
+    
     struct CombinationResult: Codable {
-        let combinationID: Int
+        let combinationId: Int
         let title, content: String
         let hashTagList: [String]
         let combinationImageList: [String]
         let isCombinationLike: Bool
-
-        enum CodingKeys: String, CodingKey {
-            case combinationID = "combinationId"
-            case title, content, hashTagList, combinationImageList, isCombinationLike
-        }
     }
-
+    
     struct MemberResult: Codable {
-        let memberID: Int
-        let name, profileImageURL: String?
-
-        enum CodingKeys: String, CodingKey {
-            case memberID = "memberId"
-            case name
-            case profileImageURL = "profileImageUrl"
-        }
+        let memberId: Int
+        let name: String
+        let profileImageUrl: String?
     }
 }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/View/Comments/CommentsView.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/View/Comments/CommentsView.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 class CommentsView: UIStackView {
     
@@ -26,7 +27,7 @@ class CommentsView: UIStackView {
     }
     
     func addViews() {
-//        addArrangedSubviews([CommentView(.comment), CommentView(.reply), CommentView(.reply), CommentView(.comment), CommentView(.reply), CommentView(.comment, isLast: true)])
+        //        addArrangedSubviews([CommentView(.comment), CommentView(.reply), CommentView(.reply), CommentView(.comment), CommentView(.reply), CommentView(.comment, isLast: true)])
     }
     
     func configureComments(_ comments: [CombinationCommentModel.CombinationCommentList]) {
@@ -46,9 +47,14 @@ class CommentsView: UIStackView {
     }
     
     private func configureCommentView(_ view: CommentView, with data: CombinationCommentModel.CombinationCommentList) {
-        view.nameLabel.text = data.memberName
-        view.dateLabel.text = data.updatedAt
-        view.contentLabel.text = data.content
-        view.replyCountLabel.text = "답글 \(data.childCount)"
+        if let imageUrlString = data.memberProfile {
+            if let imageUrl = URL(string: imageUrlString) {
+                view.profileImageView.kf.setImage(with: imageUrl)
+            }
+            view.nameLabel.text = data.memberNickName
+            view.dateLabel.text = data.updatedAt
+            view.contentLabel.text = data.content
+            view.replyCountLabel.text = "답글 \(data.childCount)"
+        }
     }
 }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
@@ -155,19 +155,30 @@ class TodayCombinationDetailViewController: UIViewController {
     @objc func commentsInputButtonTapped() {
         guard let text = todayCombinationDetailView.commentsInputView.textField.text, !text.isEmpty else { return }
         
+        todayCombinationDetailView.commentsInputView.textField.resignFirstResponder() // 키보드 숨기기
+
         let input = CombinationCommentInput.postCommentInput(content: text, parentId: "0")
-        
+
         if let combinationId = self.combinationId {
             CombinationDetailDataManager().postComment(combinationId, input)
             prepare()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                // 댓글 작성 후 스크롤뷰 최하단으로 이동
-                self.todayCombinationDetailView.scrollView.setContentOffset(CGPoint(x: 0, y: self.todayCombinationDetailView.scrollView.contentSize.height - self.todayCombinationDetailView.scrollView.bounds.height), animated: true)
-            }
-        }
 
-        todayCombinationDetailView.commentsInputView.textField.text = "" // 텍스트필드 초기화
-        todayCombinationDetailView.commentsInputView.textField.resignFirstResponder() // 키보드 숨기기
+            DispatchQueue.main.async {
+                let alert = UIAlertController(title: nil, message: "댓글이 작성되었습니다.", preferredStyle: .alert)
+                self.present(alert, animated: true, completion: nil)
+
+                Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false, block: { _ in alert.dismiss(animated: true, completion: nil)} )
+                
+                // 스크롤뷰를 맨 위로 이동
+                self.todayCombinationDetailView.scrollView.contentOffset = .zero
+            }
+
+            fetchingMore = false
+            totalPageNum = 0
+            nowPageNum = 0
+            
+            todayCombinationDetailView.commentsInputView.textField.text = "" // 텍스트필드 초기화
+        }
     }
     
     // MARK: - 답글쓰기

--- a/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
@@ -27,20 +27,6 @@ class TodayCombinationDetailViewController: UIViewController {
         view = todayCombinationDetailView
     }
     
-    // MARK: - 오늘의 조합 홈 화면으로 돌아갈 때
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        // 키보드 관련 알림 해제
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillHideNotification, object: nil)
-
-        // 뷰 컨트롤러가 화면에서 사라질 때 알림 발송
-        if isMovingFromParent {
-            NotificationCenter.default.post(name: NSNotification.Name("TodayCombinationDetailViewControllerDismissed"), object: nil)
-        }
-    }
-    
     // MARK: - viewDidLoad()
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -175,6 +161,7 @@ class TodayCombinationDetailViewController: UIViewController {
             CombinationDetailDataManager().postComment(combinationId, input)
             prepare()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                // 댓글 작성 후 스크롤뷰 최하단으로 이동
                 self.todayCombinationDetailView.scrollView.setContentOffset(CGPoint(x: 0, y: self.todayCombinationDetailView.scrollView.contentSize.height - self.todayCombinationDetailView.scrollView.bounds.height), animated: true)
             }
         }

--- a/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
@@ -68,6 +68,8 @@ class TodayCombinationDetailViewController: UIViewController {
     func updateUIWithData() {
         self.todayCombinationDetailView.imageCollectionView.reloadData()
         
+        print("DEBUG - \(String(describing: combinationDetailData?.result.combinationResult.combinationImageList))")
+        
         self.todayCombinationDetailView.pageControl.numberOfPages =  combinationDetailData?.result.combinationResult.combinationImageList.count ?? 0
         
         self.todayCombinationDetailView.userNameLabel.text = "\(combinationDetailData?.result.memberResult.name ?? "이름") 님의 레시피"

--- a/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeDataManager.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeDataManager.swift
@@ -10,33 +10,11 @@ import Alamofire
 class CombinationHomeDataManager {
     
     private let baseURL = "https://drink-gourmet.kro.kr"
-    private let testAccessToken: HTTPHeaders = [
-        "Authorization": "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrYWthb18xMjM0NTY3ODkiLCJpYXQiOjE3MDc4MTY0OTQsImV4cCI6MTcwODQyMTI5NH0.tL3VWPK1W_3IR3_eIyOS0Lmn1qNTnfKRcb-nkNU7Glo"
-    ]
     
-    // MARK: - 오늘의 조합 홈 목록 가져오기
-    func fetchCombinationHomeData(_ parameters: CombinationHomeInput,
+    // MARK: - 오늘의 조합 홈 조회
+    func fetchCombinationHomeData(_ parameters: CombinationHomeInput.fetchCombinationHomeDataInput,
                                   _ viewController: TodayCombinationViewController,
                                   completion: @escaping (CombinationHomeModel?) -> Void) {
-        
-        // Alamofire 요청
-        AF.request("\(baseURL)/combinations",
-                   method: .get,
-                   parameters: parameters,
-                   headers: testAccessToken)
-        .validate()
-        .responseDecodable(of: CombinationHomeModel.self) { response in
-            switch response.result {
-            case .success(let result):
-                print("오늘의조합 홈 - 네트워킹 성공")
-                completion(result)
-            case .failure(let error):
-                print("오늘의조합 홈 - \(error)")
-                completion(nil)
-            }
-        }
-    }
-/*
         do {
             // Keychain에서 액세스 토큰 가져오기
             let accessToken = try Keychain.shared.getToken(kind: .accessToken)
@@ -47,7 +25,7 @@ class CombinationHomeDataManager {
             ]
             
             // Alamofire 요청
-            AF.request("https://drink-gourmet.kro.kr/combinations",
+            AF.request("\(baseURL)/combinations",
                        method: .get,
                        parameters: parameters,
                        headers: headers)
@@ -55,10 +33,10 @@ class CombinationHomeDataManager {
             .responseDecodable(of: CombinationHomeModel.self) { response in
                 switch response.result {
                 case .success(let result):
-                    print("오늘의조합 홈 목록 가져오기 - 네트워킹 성공")
+                    print("오늘의 조합 홈 조회 - 네트워킹 성공")
                     completion(result)
                 case .failure(let error):
-                    print("오늘의조합 홈 목록 가져오기 - \(error)")
+                    print("오늘의 조합 홈 조회 - \(error)")
                     completion(nil)
                 }
             }
@@ -66,27 +44,37 @@ class CombinationHomeDataManager {
             print("Failed to get access token")
         }
     }
-*/
+
     
-    // MARK: - 오늘의 조합 검색 후 목록 가져오기
-    func fetchCombinationDataForSearch(_ parameters: CombinationSearchInput,
+    // MARK: - 오늘의 조합 검색
+    func fetchCombinationSearchData (_ parameters: CombinationHomeInput.fetchCombinationSearchDataInput,
                                        _ viewController: CombinationSearchVC,
                                        completion: @escaping (CombinationHomeModel?) -> Void) {
-        
-        AF.request("\(baseURL)/combinations/search",
-                   method: .get,
-                   parameters: parameters,
-                   headers: testAccessToken)
-        .validate()
-        .responseDecodable(of: CombinationHomeModel.self) { response in
-            switch response.result {
-            case .success(let result):
-                print("오늘의조합 검색 - 네트워킹 성공")
-                completion(result)
-            case .failure(let error):
-                print("오늘의조합 검색 - \(error)")
-                completion(nil)
+        do {
+            let accessToken = try Keychain.shared.getToken(kind: .accessToken)
+            
+            let headers: HTTPHeaders = [
+                "Authorization": "Bearer \(accessToken)"
+            ]
+            
+            AF.request("\(baseURL)/combinations/search",
+                       method: .get,
+                       parameters: parameters,
+                       headers: headers)
+            .validate()
+            .responseDecodable(of: CombinationHomeModel.self) { response in
+                switch response.result {
+                case .success(let result):
+                    print("오늘의 조합 검색 - 네트워킹 성공")
+                    completion(result)
+                case .failure(let error):
+                    print("오늘의 조합 검색 - \(error)")
+                    completion(nil)
+                }
             }
+        } catch {
+            print("Failed to get access token")
         }
     }
+    
 }

--- a/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeInput.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeInput.swift
@@ -5,13 +5,15 @@
 //  Created by 이승민 on 2/10/24.
 //
 
-import Foundation
-
-struct CombinationHomeInput: Codable {
-    var page: Int?
-}
-
-struct CombinationSearchInput: Codable {
-    var page: Int?
-    var keyword: String?
+struct CombinationHomeInput {
+    
+    struct fetchCombinationHomeDataInput: Codable {
+        var page: Int?
+    }
+    
+    struct fetchCombinationSearchDataInput: Codable {
+        var page: Int?
+        var keyword: String?
+    }
+    
 }

--- a/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeModel.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/Model/CombinationHomeModel.swift
@@ -5,10 +5,8 @@
 //  Created by 이승민 on 2/10/24.
 //
 
-import Foundation
-
-// MARK: - CombinationHomeModel
 struct CombinationHomeModel: Codable {
+    
     let isSuccess: Bool
     let code, message: String
     let result: CombinationHomeModelResult
@@ -26,4 +24,5 @@ struct CombinationHomeModel: Codable {
         let likeCount, commentCount: Int
         let hashTageList: [String]
     }
+    
 }

--- a/DrinkingGourmet/Source/TodayCombination/Home/View/TodayCombinationCell.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/View/TodayCombinationCell.swift
@@ -11,6 +11,7 @@ import Then
 
 class TodayCombinationCell: UITableViewCell {
     
+    // MARK: - View
     let mainImage = UIImageView().then {
         $0.image = UIImage(named: "img_community_today_thumbnail")
         $0.layer.cornerRadius = 8
@@ -56,13 +57,8 @@ class TodayCombinationCell: UITableViewCell {
         $0.contentMode = .scaleAspectFit
 //        $0.isHidden = true
     }
-    
-    // MARK: - 셀 간 간격 조정
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 15, right: 0))
-    }
 
+    // MARK: - Init
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupContentView()
@@ -74,8 +70,13 @@ class TodayCombinationCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
-    // MARK: - 셀 테두리 설정
-    func setupContentView() {
+    // MARK: - UI
+    override func layoutSubviews() { // 셀 간 간격 설정
+        super.layoutSubviews()
+        contentView.frame = contentView.frame.inset(by: UIEdgeInsets(top: 0, left: 0, bottom: 15, right: 0))
+    }
+
+    func setupContentView() { // 셀 테두리 설정
         contentView.layer.borderWidth = 1
         contentView.layer.cornerRadius = 8
         contentView.layer.borderColor = UIColor(red: 0.935, green: 0.935, blue: 0.935, alpha: 1).cgColor

--- a/DrinkingGourmet/Source/TodayCombination/Home/ViewController/CombinationSearchVC.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/ViewController/CombinationSearchVC.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class CombinationSearchVC: UIViewController {
     
+    // MARK: - Properties
     var exampleArray = ["오늘의조합 검색화면 TEST", "오늘의조합 검색화면 TEST", "오늘의조합 검색화면 TEST", "오늘의조합 검색화면 TEST", "오늘의조합 검색화면 TEST", "오늘의조합 검색화면 TEST"]
     
     private let searchResultView = SearchResultView()
@@ -23,7 +24,7 @@ class CombinationSearchVC: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .white
 
-        prepare()
+        setupTextField()
         setupTableView()
         setupButton()
     }
@@ -40,20 +41,19 @@ class CombinationSearchVC: UIViewController {
         navigationController?.setNavigationBarHidden(false, animated: false) // 검색 화면에서 빠져나올 때 네비게이션 바 보이기
     }
     
-    // MARK: - 기초 설정
-    func prepare() {
-        // 키보드 자동 띄우기
-        searchResultView.searchBar.textField.becomeFirstResponder()
+    // MARK: - 텍스트필드 설정
+    func setupTextField() {
+        let tf = searchResultView.searchBar.textField
         
-        searchResultView.searchBar.textField.attributedPlaceholder = NSAttributedString(
+        tf.delegate = self
+        tf.becomeFirstResponder() // 키보드 자동 띄우기
+        tf.attributedPlaceholder = NSAttributedString(
             string: "오늘의 조합 검색",
             attributes: [
                 .foregroundColor: UIColor(red: 0.38, green: 0.38, blue: 0.38, alpha: 1),
                 .font: UIFont(name: "AppleSDGothicNeo-Medium", size: 16)!
             ]
         )
-        
-        searchResultView.searchBar.textField.delegate = self
     }
     
     // MARK: - 테이블뷰 설정
@@ -61,8 +61,6 @@ class CombinationSearchVC: UIViewController {
         let tb = searchResultView.tableView
         
         tb.dataSource = self
-        tb.delegate = self
-        
         tb.rowHeight = 48
         tb.register(SearchResultCell.self, forCellReuseIdentifier: "SearchResultCell")
     }
@@ -85,6 +83,7 @@ class CombinationSearchVC: UIViewController {
 
 }
 
+// MARK: - UITableViewDataSource
 extension CombinationSearchVC: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return exampleArray.count
@@ -101,13 +100,9 @@ extension CombinationSearchVC: UITableViewDataSource {
     }
 }
 
-extension CombinationSearchVC: UITableViewDelegate {
-    
-}
-
-// MARK: - 검색 결과 화면 X 버튼 터치 시 행 삭제
+// MARK: - SearchResultCellDelegate
 extension CombinationSearchVC: SearchResultCellDelegate {
-    func didTapDeleteButton(in cell: SearchResultCell) {
+    func didTapDeleteButton(in cell: SearchResultCell) { // X 버튼 터치 시 행 삭제
         guard let indexPath = searchResultView.tableView.indexPath(for: cell) else { return }
         exampleArray.remove(at: indexPath.row)
         searchResultView.tableView.deleteRows(at: [indexPath], with: .automatic)
@@ -119,9 +114,9 @@ extension CombinationSearchVC: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder() // 키보드 숨기기
         
-        let input = CombinationSearchInput(page: 0, keyword: searchResultView.searchBar.textField.text)
+        let input = CombinationHomeInput.fetchCombinationSearchDataInput(page: 0, keyword: searchResultView.searchBar.textField.text)
         
-        CombinationHomeDataManager().fetchCombinationDataForSearch(input, self) { [weak self] model in
+        CombinationHomeDataManager().fetchCombinationSearchData(input, self) { [weak self] model in
             if let model = model {
                 self?.navigationController?.popViewController(animated: true)
                 guard let todayCombinationViewController = self?.navigationController?.topViewController as? TodayCombinationViewController else {

--- a/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
@@ -28,12 +28,21 @@ class TodayCombinationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
+        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: NSNotification.Name("TodayCombinationDetailViewControllerDismissed"), object: nil)
         
         prepare()
         setupNaviBar()
         setupTextField()
         setupTableView()
         setupFloatingButton()
+    }
+    
+    @objc func handleNotification() {
+        prepare()
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - 초기 설정

--- a/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
@@ -11,6 +11,7 @@ import Then
 
 class TodayCombinationViewController: UIViewController {
     
+    // MARK: - Properties
     var arrayCombinationHome: [CombinationHomeModel.CombinationHomeList] = []
     var fetchingMore: Bool = false
     var totalPageNum: Int = 0
@@ -30,22 +31,15 @@ class TodayCombinationViewController: UIViewController {
         
         prepare()
         setupNaviBar()
+        setupTextField()
         setupTableView()
         setupFloatingButton()
     }
     
+    // MARK: - 초기 설정
     func prepare() {
-        todayCombinationView.customSearchBar.textField.delegate = self
+        let input = CombinationHomeInput.fetchCombinationHomeDataInput(page: 0)
         
-        todayCombinationView.customSearchBar.textField.attributedPlaceholder = NSAttributedString(
-            string: "오늘의 조합 검색",
-            attributes: [
-                .foregroundColor: UIColor(red: 0.38, green: 0.38, blue: 0.38, alpha: 1),
-                .font: UIFont(name: "AppleSDGothicNeo-Medium", size: 16)!
-            ]
-        )
-        
-        let input = CombinationHomeInput(page: 0)
         CombinationHomeDataManager().fetchCombinationHomeData(input, self) { [weak self] model in
             if let model = model {
                 self?.totalPageNum = model.result.totalPage
@@ -76,6 +70,20 @@ class TodayCombinationViewController: UIViewController {
         navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
     }
     
+    // MARK: - 텍스트필드 설정
+    func setupTextField() {
+        let tb = todayCombinationView.customSearchBar.textField
+        
+        tb.delegate = self
+        tb.attributedPlaceholder = NSAttributedString(
+            string: "오늘의 조합 검색",
+            attributes: [
+                .foregroundColor: UIColor(red: 0.38, green: 0.38, blue: 0.38, alpha: 1),
+                .font: UIFont(name: "AppleSDGothicNeo-Medium", size: 16)!
+            ]
+        )
+    }
+    
     // MARK: - 테이블뷰 설정
     func setupTableView() {
         let tb = todayCombinationView.tableView
@@ -97,27 +105,6 @@ class TodayCombinationViewController: UIViewController {
         navigationController?.pushViewController(vc, animated: true)
     }
     
-    // MARK: - 페이징
-    func fetchNextPage() {
-//        print(#function)
-//        print("nowPageNum - \(nowPageNum)") // 현재 페이지
-        nowPageNum = nowPageNum + 1
-        let nextPage = nowPageNum
-//        print("nextPage : \(nextPage)") // 다음 요청할 페이지
-        let input = CombinationHomeInput(page: nextPage)
-        
-        CombinationHomeDataManager().fetchCombinationHomeData(input, self) { [weak self] model in
-//            print(input)
-//            print("테스트")
-            if let model = model {
-                self?.arrayCombinationHome += model.result.combinationList
-                self?.fetchingMore = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
-                    self?.todayCombinationView.tableView.reloadData()
-                }
-            }
-        }
-    }
 }
 
 // MARK: - UITextFieldDelegate
@@ -172,6 +159,7 @@ extension TodayCombinationViewController: UITableViewDelegate {
         navigationController?.pushViewController(todayCombinationDetailVC, animated: true)
     }
 
+    // 페이징
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
@@ -185,6 +173,27 @@ extension TodayCombinationViewController: UITableViewDelegate {
                 fetchingMore = true
 //                print("fetchingMore - \(fetchingMore)")
                 fetchNextPage()
+            }
+        }
+    }
+    
+    func fetchNextPage() {
+//        print(#function)
+//        print("nowPageNum - \(nowPageNum)") // 현재 페이지
+        nowPageNum = nowPageNum + 1
+        let nextPage = nowPageNum
+//        print("nextPage : \(nextPage)") // 다음 요청할 페이지
+        let input = CombinationHomeInput.fetchCombinationHomeDataInput(page: nextPage)
+        
+        CombinationHomeDataManager().fetchCombinationHomeData(input, self) { [weak self] model in
+//            print(input)
+//            print("테스트")
+            if let model = model {
+                self?.arrayCombinationHome += model.result.combinationList
+                self?.fetchingMore = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    self?.todayCombinationView.tableView.reloadData()
+                }
             }
         }
     }

--- a/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Home/ViewController/TodayCombinationViewController.swift
@@ -28,21 +28,12 @@ class TodayCombinationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .white
-        NotificationCenter.default.addObserver(self, selector: #selector(handleNotification), name: NSNotification.Name("TodayCombinationDetailViewControllerDismissed"), object: nil)
         
         prepare()
         setupNaviBar()
         setupTextField()
         setupTableView()
         setupFloatingButton()
-    }
-    
-    @objc func handleNotification() {
-        prepare()
-    }
-    
-    deinit {
-        NotificationCenter.default.removeObserver(self)
     }
     
     // MARK: - 초기 설정


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
[O] 기능 추가<br>
[] 기능 삭제<br>
[] 버그 수정<br>
[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>
## 반영 브랜치
feat/today-combination -> main

<br>

## 변경 사항
1. 오늘의 조합 엑세스 토큰 하드코딩 해놨던거 Keychain에서 가져오는 것으로 코드 수정 및 리펙토링
2. 오늘의 조합 댓글 구현 (대댓글 구현 전)
3. 댓글 입력버튼 누르면 화면 갱신

<br>

## 스크린샷(선택사항)
<img width="500" alt="image" src="https://github.com/UMC5th-DrinkingGourmet/dg-FrontEnd/assets/147085742/34b5c477-b138-40a1-9971-b05f54a3cf87">

https://github.com/UMC5th-DrinkingGourmet/dg-FrontEnd/assets/147085742/e32e92d3-bca6-496f-8fb6-d90687eaaa11

## 기타
1. 댓글 작성완료되면 자기가 작성한거 바로 볼 수 있게 스크롤뷰 최하단으로 이동하려다가 페이징 처리 문제로 최상단으로 이동하게 구현했습니다.
2. 대댓글 UI에서 답글쓰기 버튼 삭제해야합니다.