### PR TITLE
Feat: 오늘의 조합 게시글 삭제 API 연동

### DIFF
--- a/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/Model/CombinationDetailDataManager.swift
@@ -92,7 +92,8 @@ class CombinationDetailDataManager {
     
     
     // MARK: - 오늘의 조합 삭제
-    func deleteCombination (_ combinationID: Int) {
+    func deleteCombination (_ combinationID: Int,
+                            completion: @escaping () -> Void) {
         do {
             let accessToken = try Keychain.shared.getToken(kind: .accessToken)
             

--- a/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
+++ b/DrinkingGourmet/Source/TodayCombination/Detail/ViewController/TodayCombinationDetailViewController.swift
@@ -142,10 +142,14 @@ class TodayCombinationDetailViewController: UIViewController {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         
         let removeAction = UIAlertAction(title: "삭제하기", style: .destructive) {_ in
-//            if let combinationId = self.combinationId {
-//                CombinationDetailDataManager().deleteCombination(combinationId)
-//                self.navigationController?.popViewController(animated: true)
-//            }
+            guard let combinationId = self.combinationId else { return }
+            
+            CombinationDetailDataManager().deleteCombination(combinationId) {
+                // 오늘의 조합 삭제는 잘 되는데 자동으로 pop이 되지 않는 버그 있음
+                DispatchQueue.main.async {
+                    self.navigationController?.popViewController(animated: true)
+                }
+            }
         }
         
         let modifyAction = UIAlertAction(title: "수정하기", style: .default, handler: nil)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
[O] 기능 추가<br>
[] 기능 삭제<br>
[] 버그 수정<br>
[] 의존성, 환경 변수, 빌드 관련 코드 업데이트
<br>
## 반영 브랜치
feat/login -> dev

<br>

## 변경 사항
1. 오늘의 조합 게시글 삭제 API 연동
<br>

## 스크린샷(선택사항)

## 기타
1. 삭제API는 잘 작동되는데 삭제하고 홈 화면으로 pop이 안됨
2. 일단 오늘의조합은 여기까지 해놓고 레시피북으로 넘어가겠습니다.