### PR TITLE
[#142] 다른 기기에서 동일 계정으로 로그인 시 회원가입으로 처리되는 문제 수정

### DIFF
--- a/DrinkingGourmet.xcodeproj/project.pbxproj
+++ b/DrinkingGourmet.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2E0274E02B6FCF5200F92177 /* MainMenuViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0274DF2B6FCF5200F92177 /* MainMenuViewController.swift */; };
 		2E0274E62B6FEF3E00F92177 /* UserDefaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0274E52B6FEF3E00F92177 /* UserDefaultManager.swift */; };
 		2E06A6F12C1EE16100FF5449 /* AppleAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E06A6F02C1EE16100FF5449 /* AppleAuthViewModel.swift */; };
+		2E22A47B2C47BFD900D38881 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E22A47A2C47BFD900D38881 /* File.swift */; };
 		2E3E5A7D2B6C04590000E651 /* UploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E5A7C2B6C04590000E651 /* UploadViewController.swift */; };
 		2E3E5A7F2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */; };
 		2E5407962B84BAF100724513 /* RecipeBookUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5407952B84BAF100724513 /* RecipeBookUploadViewController.swift */; };
@@ -169,6 +170,7 @@
 		2E0274DF2B6FCF5200F92177 /* MainMenuViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenuViewController.swift; sourceTree = "<group>"; };
 		2E0274E52B6FEF3E00F92177 /* UserDefaultManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultManager.swift; sourceTree = "<group>"; };
 		2E06A6F02C1EE16100FF5449 /* AppleAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthViewModel.swift; sourceTree = "<group>"; };
+		2E22A47A2C47BFD900D38881 /* File.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = File.swift; sourceTree = "<group>"; };
 		2E3E5A7C2B6C04590000E651 /* UploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadViewController.swift; sourceTree = "<group>"; };
 		2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadedImgCollectionViewCell.swift; sourceTree = "<group>"; };
 		2E5407952B84BAF100724513 /* RecipeBookUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeBookUploadViewController.swift; sourceTree = "<group>"; };
@@ -908,6 +910,7 @@
 				56543EC62B7EF0620099E648 /* CombinationUploadModel.swift */,
 				56BBF3F52C359F5B0058B19B /* RecommendDTO.swift */,
 				56BBF42B2C3812DA0058B19B /* MyPageDTO.swift */,
+				2E22A47A2C47BFD900D38881 /* File.swift */,
 			);
 			path = Dto;
 			sourceTree = "<group>";
@@ -1309,6 +1312,7 @@
 				56B9DCCC2BCBF37700D08D22 /* ReportCompletePopUpView.swift in Sources */,
 				56BBF3512C32BDDD0058B19B /* QuestionViewController.swift in Sources */,
 				5668A34D2B6FBAF00009FCD6 /* RecipeBookDetailViewController.swift in Sources */,
+				2E22A47B2C47BFD900D38881 /* File.swift in Sources */,
 				56BBF4302C381F680058B19B /* MyRecommendViewController.swift in Sources */,
 				56BBF4022C35A23E0058B19B /* SelectMoodViewController.swift in Sources */,
 				56BBF3EC2C359CF40058B19B /* RecommendGuideView.swift in Sources */,
@@ -1349,7 +1353,6 @@
 				56BBF4042C35AD550058B19B /* InputMoodeViewController.swift in Sources */,
 				56BBF40E2C35B9150058B19B /* RecommendResultView.swift in Sources */,
 				56BBF4262C378D310058B19B /* LikeCombinationViewController.swift in Sources */,
-				56543ECB2B7EF1500099E648 /* CombinationUploadDataManager.swift in Sources */,
 				56BBF4282C378D420058B19B /* LikeRecipeBookViewController.swift in Sources */,
 				5625E3792BB962D700269BBF /* SettingView.swift in Sources */,
 				2E871E702B6E3DCB00B4BB70 /* InputTextFieldView.swift in Sources */,

--- a/DrinkingGourmet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DrinkingGourmet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kakao/kakao-ios-sdk",
       "state" : {
-        "revision" : "e9e649d3ba823c3673867d3d09010fc77005a940",
-        "version" : "2.22.3"
+        "revision" : "08089eeffc9b442da1c7343a70bf66c6de1a72c9",
+        "version" : "2.22.4"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-spm",
       "state" : {
-        "revision" : "1d29eccc24cc8b75bff9f6804155112c0ffc9605",
-        "version" : "4.4.3"
+        "revision" : "b842598f1295f3ffa1475b1580672d1fe5b83580",
+        "version" : "4.5.0"
       }
     },
     {

--- a/DrinkingGourmet/App/SceneDelegate.swift
+++ b/DrinkingGourmet/App/SceneDelegate.swift
@@ -17,14 +17,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         let window = UIWindow(windowScene: windowScene)
         self.window = window
-//        window.rootViewController = UINavigationController(rootViewController: UploadViewController())
         
-//        do {
-//            try Keychain.shared.deleteToken(kind: .refreshToken)
-//            print("Deleted Access Token")
-//        } catch {
-//            print("Failed to delete Access Token: \(error)")
-//        }
+        do {
+            try Keychain.shared.deleteToken(kind: .refreshToken)
+            print("Deleted Access Token")
+        } catch {
+            print("Failed to delete Access Token: \(error)")
+        }
 
         
         do {

--- a/DrinkingGourmet/Source/Service/Dto/File.swift
+++ b/DrinkingGourmet/Source/Service/Dto/File.swift
@@ -1,0 +1,23 @@
+//
+//  File.swift
+//  DrinkingGourmet
+//
+//  Created by hwijinjeong on 7/17/24.
+//
+
+import Foundation
+
+struct UserStatusResponse: Decodable {
+    var isSuccess: Bool
+    var code: String
+    var message: String
+    var result: UserStatus
+}
+
+struct UserStatus: Decodable {
+    var provider: String
+    var nickName: String
+    var memberId: Int
+    var newMember: Bool
+    var createdAt: String
+}

--- a/DrinkingGourmet/Source/UserAuthentication/UserDefaultManager.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/UserDefaultManager.swift
@@ -15,6 +15,7 @@ class UserDefaultManager {
     static let shared = UserDefaultManager()
     
     enum UDKey: String {
+        case userId
         case userName
         case userBirth
         case userPhoneNumber
@@ -27,6 +28,15 @@ class UserDefaultManager {
     }
     
     let ud = UserDefaults.standard
+    
+    var userId: String {
+        get {
+            ud.string(forKey: UDKey.userId.rawValue) ?? "-1"
+        }
+        set {
+            ud.setValue(newValue, forKey: UDKey.userId.rawValue)
+        }
+    }
     
     var userName: String {
         get {

--- a/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/ProfileCreationViewController.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/ProfileCreationViewController.swift
@@ -293,7 +293,7 @@ extension ProfileCreationViewController {
             providerId: UserDefaultManager.shared.providerId
         )
                 
-        SignUpService.shared.sendUserInfo(userInfo) {
+        SignUpService.shared.sendUserInfo(userInfo) {_ in 
             let tabbarVC = TabBarViewController()
             self.navigationController?.pushViewController(tabbarVC, animated: true)
         }


### PR DESCRIPTION
## 👀 이슈 번호
<!-- 관련 이슈를 적어주세요 -->
resolve #142

## ✨ 작업한 내용
- 애플 로그인 및 카카오 로그인 버튼 클릭 시 서버에 로그인 요청
- 서버 응답 결과를 기반으로 화면 이동 결정 (새 회원일 경우 `TermsViewController`, 기존 회원일 경우 `TabBarViewController`)
- 응답 헤더에서 받은 액세스 토큰과 리프레시 토큰을 키체인에 저장

## 🌀 PR Point
- 이번 변경으로 인해 다른 기기에서도 동일한 계정으로 로그인 시, 회원가입이 아닌 기존 회원으로 인식되도록 수정되었습니다. 기존에는 공기계에서 동일 계정으로 로그인할 때, 해당 기기에는 액세스 및 리프레시 토큰이 없어서 새로운 회원으로 처리되었습니다. 이제는 애플 로그인 및 카카오 로그인 버튼을 눌렀을 때 서버에 로그인 요청을 보내고, 서버 응답 결과에 따라 화면 이동을 조정하였습니다.

- 추후 서버 쪽에서 유저 상태 구별 관련 api를 만들면, 리팩토링 및 수정 계획이 있습니다.(현재는 새로 회원가입 할 경우 버그가 있음)


## 📷 스크린샷 또는 GIF
<!-- <img src="" width="30%"> -->


## 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
