### PR TITLE
[KAN-23][refactor] 자동 로그인 시, RefreshToken 유효성 검증 방식 변경(iat 기반 만료 시간 검증)

### DIFF
--- a/DrinkingGourmet.xcodeproj/project.pbxproj
+++ b/DrinkingGourmet.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2E0274E62B6FEF3E00F92177 /* UserDefaultManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E0274E52B6FEF3E00F92177 /* UserDefaultManager.swift */; };
 		2E06A6F12C1EE16100FF5449 /* AppleAuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E06A6F02C1EE16100FF5449 /* AppleAuthViewModel.swift */; };
 		2E22A47B2C47BFD900D38881 /* SignInResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E22A47A2C47BFD900D38881 /* SignInResponseDTO.swift */; };
+		2E2DE4EB2C8DEF470049ACFC /* TokenParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E2DE4EA2C8DEF470049ACFC /* TokenParser.swift */; };
 		2E3E5A7D2B6C04590000E651 /* UploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E5A7C2B6C04590000E651 /* UploadViewController.swift */; };
 		2E3E5A7F2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */; };
 		2E5407962B84BAF100724513 /* RecipeBookUploadViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5407952B84BAF100724513 /* RecipeBookUploadViewController.swift */; };
@@ -181,6 +182,7 @@
 		2E0274E52B6FEF3E00F92177 /* UserDefaultManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultManager.swift; sourceTree = "<group>"; };
 		2E06A6F02C1EE16100FF5449 /* AppleAuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleAuthViewModel.swift; sourceTree = "<group>"; };
 		2E22A47A2C47BFD900D38881 /* SignInResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInResponseDTO.swift; sourceTree = "<group>"; };
+		2E2DE4EA2C8DEF470049ACFC /* TokenParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TokenParser.swift; sourceTree = "<group>"; };
 		2E3E5A7C2B6C04590000E651 /* UploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadViewController.swift; sourceTree = "<group>"; };
 		2E3E5A7E2B6C0CA10000E651 /* UploadedImgCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadedImgCollectionViewCell.swift; sourceTree = "<group>"; };
 		2E5407952B84BAF100724513 /* RecipeBookUploadViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipeBookUploadViewController.swift; sourceTree = "<group>"; };
@@ -595,6 +597,7 @@
 		2EB001902B5E40A400B74580 /* UserAuthentication */ = {
 			isa = PBXGroup;
 			children = (
+				2E2DE4EA2C8DEF470049ACFC /* TokenParser.swift */,
 				2E56A0DC2B78861B007747ED /* KeyChain.swift */,
 				2EE2E88C2B657A52006F81E9 /* KakaoAuthViewModel.swift */,
 				2E06A6F02C1EE16100FF5449 /* AppleAuthViewModel.swift */,
@@ -1408,6 +1411,7 @@
 				56BBF4322C381F740058B19B /* MyCombinationViewController.swift in Sources */,
 				2E85190A2B6D23F10052EB30 /* ProfileCreationViewController.swift in Sources */,
 				56BBF3F42C359F460058B19B /* RecommendService.swift in Sources */,
+				2E2DE4EB2C8DEF470049ACFC /* TokenParser.swift in Sources */,
 				2EB865F52C68AB5D00CFF348 /* UserInfo.swift in Sources */,
 				56F8A7182B8000CA000F6CA4 /* LikeView.swift in Sources */,
 				56BBF35E2C33FEE80058B19B /* AnswerView.swift in Sources */,

--- a/DrinkingGourmet/App/AppDelegate.swift
+++ b/DrinkingGourmet/App/AppDelegate.swift
@@ -16,6 +16,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         
+        sleep(1)
+        
         let appKey = Bundle.main.infoDictionary?["KAKAO_APP_KEY"] ?? ""
         
         KakaoSDK.initSDK(appKey: appKey as! String)

--- a/DrinkingGourmet/App/Base.lproj/LaunchScreen.storyboard
+++ b/DrinkingGourmet/App/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -11,10 +13,105 @@
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="img_splash_background" translatesAutoresizingMaskIntoConstraints="NO" id="GqI-oM-sLZ">
+                                <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yWB-fV-b1c">
+                                <rect key="frame" x="39.999999999999986" y="100" width="183.66666666666663" height="169"/>
+                                <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <attributedString key="attributedText">
+                                    <fragment content="술과">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <font key="NSOriginalFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="음식의">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <font key="NSOriginalFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="미식">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <font key="NSOriginalFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content=" ">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="여행">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <font key="NSOriginalFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment>
+                                        <string key="content" base64-UTF8="YES">
+Cg
+</string>
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="12" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                    <fragment content="음주미식회">
+                                        <attributes>
+                                            <color key="NSColor" red="0.99999600649999998" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            <font key="NSFont" size="40" name="AppleSDGothicNeo-Bold"/>
+                                            <font key="NSOriginalFont" metaFont="system" size="17"/>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="left" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
+                                        </attributes>
+                                    </fragment>
+                                </attributedString>
+                                <color key="highlightedColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="shadowColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </label>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="GqI-oM-sLZ" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" id="LdL-cd-0Mv"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="GqI-oM-sLZ" secondAttribute="trailing" id="P3s-1r-m71"/>
+                            <constraint firstItem="GqI-oM-sLZ" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="aZE-oh-1L6"/>
+                            <constraint firstAttribute="bottom" secondItem="GqI-oM-sLZ" secondAttribute="bottom" id="fzH-MM-aax"/>
+                            <constraint firstItem="yWB-fV-b1c" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" constant="40" id="xoi-U8-dja"/>
+                            <constraint firstItem="yWB-fV-b1c" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" constant="100" id="zsP-4E-ZP5"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -22,4 +119,10 @@
             <point key="canvasLocation" x="53" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <image name="img_splash_background" width="375" height="812"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/DrinkingGourmet/App/SceneDelegate.swift
+++ b/DrinkingGourmet/App/SceneDelegate.swift
@@ -27,10 +27,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 //        
         do {
             let refreshToken = try Keychain.shared.getToken(kind: .refreshToken)
-            SignService.shared.loginWithProviderInfo { [weak self] in
-                DispatchQueue.main.async {
-                    self?.window?.rootViewController = TabBarViewController() 
-                    self?.window?.makeKeyAndVisible()
+            if TokenParser.isTokenExpired(refreshToken) {
+                print("RefreshToken이 만료되었습니다. 로그인 화면을 띄웁니다.")
+                window.rootViewController = UINavigationController(rootViewController: AuthenticationViewController())
+                window.makeKeyAndVisible()
+            } else {
+                print("RefreshToken이 유효합니다. 메인 화면으로 이동합니다.")
+                SignService.shared.loginWithProviderInfo { [weak self] in
+                    DispatchQueue.main.async {
+                        self?.window?.rootViewController = TabBarViewController()
+                        self?.window?.makeKeyAndVisible()
+                    }
                 }
             }
         } catch {

--- a/DrinkingGourmet/Source/Network/Service/SignService.swift
+++ b/DrinkingGourmet/Source/Network/Service/SignService.swift
@@ -24,8 +24,9 @@ final class SignService {
     
     func sendUserInfo(_ userInfo: UserInfo, completion: @escaping (UserStatus?) -> Void) {
         let parameter = UserInfoDTO(from: userInfo)
+        let provider = UserDefaultManager.shared.provider
         
-        AF.request("\(baseURL)/kakao",
+        AF.request("\(baseURL)/\(provider)",
                    method: .post,
                    parameters: parameter,
                    encoder: JSONParameterEncoder.default,
@@ -61,7 +62,7 @@ final class SignService {
         let providerId = UserDefaultManager.shared.providerId
         let loginInfo = SignInfoDTO(provider: provider, providerId: providerId)
         
-        AF.request("\(baseURL)/kakao",
+        AF.request("\(baseURL)/\(provider)",
                    method: .post,
                    parameters: loginInfo,
                    encoder: JSONParameterEncoder.default,

--- a/DrinkingGourmet/Source/UserAuthentication/TokenParser.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/TokenParser.swift
@@ -1,0 +1,46 @@
+//
+//  TokenParser.swift
+//  DrinkingGourmet
+//
+//  Created by hwijinjeong on 9/8/24.
+//
+
+import Foundation
+
+class TokenParser {
+    
+    // payload 부분 추출
+    static func parseJWT(_ token: String) -> [String: Any]? {
+        let segments = token.split(separator: ".")
+        guard segments.count == 3 else {
+            return nil
+        }
+        
+        let base64String = String(segments[1])
+        let base64Padded = base64String.padding(toLength: ((base64String.count+3)/4)*4, withPad: "=", startingAt: 0)
+        
+        guard let decodedData = Data(base64Encoded: base64Padded, options: []) else {
+            return nil
+        }
+        
+        return try? JSONSerialization.jsonObject(with: decodedData, options: []) as? [String: Any]
+    }
+    
+    // 토큰이 만료되었는지 확인(발급 시간만으로 유효성 추정, 10일로 설정)
+    static func isTokenExpired(_ token: String, validForDays: Int = 10) -> Bool {
+        guard let payload = parseJWT(token) else {
+            return true
+        }
+        
+        if let iat = payload["iat"] as? Double {
+            let issuedDate = Date(timeIntervalSince1970: iat)
+            
+            // 10일 뒤 만료
+            let expirationDate = Calendar.current.date(byAdding: .day, value: validForDays, to: issuedDate) ?? issuedDate
+            
+            return expirationDate <= Date()
+        } else {
+            return true
+        }
+    }
+}

--- a/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/AuthenticationViewController.swift
+++ b/DrinkingGourmet/Source/UserAuthentication/Viewcontroller/AuthenticationViewController.swift
@@ -30,14 +30,15 @@ class AuthenticationViewController: UIViewController {
     
     private let titleLabel = UILabel().then {
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = 12 // 줄 사이 간격 설정
+        paragraphStyle.lineSpacing = 12
 
         let attrString = NSMutableAttributedString(string: "술과 음식의\n미식 여행\n음주미식회")
+        attrString.addAttribute(.kern, value: 0.45, range: NSMakeRange(0, attrString.length))
         attrString.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSMakeRange(0, attrString.length))
 
         $0.attributedText = attrString
         $0.textColor = .white
-        $0.font = UIFont.systemFont(ofSize: 40, weight: .heavy)
+        $0.font = UIFont.systemFont(ofSize: 40, weight: .bold)
         $0.textAlignment = .left
         $0.numberOfLines = 3
     }


### PR DESCRIPTION
## 👀 이슈 번호
<!-- 관련 이슈를 적어주세요 -->
resolve #[KAN-23]

## ✨ 작업한 내용
- 시작 화면 결정 시, RefreshToken 유효성 판단 로직을 변경. 키체인에 토큰이 있는지 여부가 아닌 JWT의 발급 시간(iat)을 기준으로 유효성을 검증하도록 수정.
- 토큰 유효 기간이 10일을 초과하면 로그인 화면으로 전환, 유효한 경우 메인 화면으로 이동하도록 변경.

## 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


## 📷 스크린샷 또는 GIF
<!-- <img src="" width="30%"> -->


## 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
