### PR TITLE
[KAN-13][refactor] configuration 방식에서 label-image 구조로 변경하여 메인페이지 버튼 패딩 문제 해결

### DIFF
--- a/DrinkingGourmet/Source/MainMenu/ViewController/MainMenuViewController.swift
+++ b/DrinkingGourmet/Source/MainMenu/ViewController/MainMenuViewController.swift
@@ -43,8 +43,20 @@ class MainMenuViewController: UIViewController {
     
     let recommendView = RecommendView()
     
+    let recipeBookLabel = UILabel().then {
+        $0.text = "레시피북"
+        $0.font = .boldSystemFont(ofSize: 20)
+        $0.textColor = .black
+        $0.textAlignment = .left
+    }
+    
+    let recipeBookIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "chevron.right")
+        $0.tintColor = .base0600
+    }
+    
     let recipeBookBtn = UIButton().then {
-        $0.trailingBtnConfiguration(title: "레시피북", font: .boldSystemFont(ofSize: 20), foregroundColor: .black, padding: 8, image: UIImage(systemName: "chevron.right"), imageSize: CGSize(width: 10, height: 12))
+        $0.backgroundColor = .clear
     }
     
     lazy var recipeBookCollectionView = UICollectionView(frame: .zero, collectionViewLayout: configureCollectionViewLayout2()).then {
@@ -57,8 +69,20 @@ class MainMenuViewController: UIViewController {
         $0.backgroundColor = .clear
     }
     
+    let todayCombiLabel = UILabel().then {
+        $0.text = "오늘의 조합"
+        $0.font = .boldSystemFont(ofSize: 20)
+        $0.textColor = .black
+        $0.textAlignment = .left
+    }
+    
+    let todayCombiIcon = UIImageView().then {
+        $0.image = UIImage(systemName: "chevron.right")
+        $0.tintColor = .base0600
+    }
+    
     let todayCombiBtn = UIButton().then {
-        $0.trailingBtnConfiguration(title: "오늘의 조합", font: .boldSystemFont(ofSize: 20), foregroundColor: .black, padding: 8, image: UIImage(systemName: "chevron.right"), imageSize: CGSize(width: 10, height: 12))
+        $0.backgroundColor = .clear
     }
     
     lazy var todayCombiCollectionView = UICollectionView(frame: .zero, collectionViewLayout: configureCollectionViewLayout3()).then {
@@ -223,14 +247,17 @@ class MainMenuViewController: UIViewController {
         contentView.addSubviews([
             bannerCollectionView,
             recommendView,
+            recipeBookLabel,
+            recipeBookIcon,
             recipeBookBtn,
             recipeBookCollectionView,
+            todayCombiLabel,
+            todayCombiIcon,
             todayCombiBtn,
             todayCombiCollectionView,
             newAlcoholBtn,
             newAlcoholImage,
             mainAdImage
-//            logoutBtn
         ])
     }
     
@@ -257,11 +284,21 @@ class MainMenuViewController: UIViewController {
             $0.height.equalTo(120)
         }
         
+        recipeBookLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.top.equalTo(recommendView.snp.bottom).offset(28)
+        }
+        
+        recipeBookIcon.snp.makeConstraints {
+            $0.leading.equalTo(recipeBookLabel.snp.trailing).offset(12)
+            $0.height.equalTo(14)
+            $0.width.equalTo(10)
+            $0.centerY.equalTo(recipeBookLabel)
+        }
+        
         recipeBookBtn.snp.makeConstraints {
-            $0.top.equalTo(recommendView.snp.bottom).offset(36)
-            $0.leading.equalToSuperview()
-            $0.height.equalTo(30)
-            $0.width.equalTo(140)
+            $0.top.leading.bottom.equalTo(recipeBookLabel)
+            $0.trailing.equalTo(recipeBookIcon)
         }
         
         recipeBookCollectionView.snp.makeConstraints {
@@ -270,11 +307,21 @@ class MainMenuViewController: UIViewController {
             $0.height.equalTo(160)
         }
         
+        todayCombiLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(20)
+            $0.top.equalTo(recipeBookCollectionView.snp.bottom).offset(28)
+        }
+        
+        todayCombiIcon.snp.makeConstraints {
+            $0.leading.equalTo(todayCombiLabel.snp.trailing).offset(12)
+            $0.height.equalTo(14)
+            $0.width.equalTo(10)
+            $0.centerY.equalTo(todayCombiLabel)
+        }
+        
         todayCombiBtn.snp.makeConstraints {
-            $0.leading.equalToSuperview()
-            $0.top.equalTo(recipeBookCollectionView.snp.bottom).offset(48)
-            $0.height.equalTo(30)
-            $0.width.equalTo(140)
+            $0.top.leading.bottom.equalTo(todayCombiLabel)
+            $0.trailing.equalTo(todayCombiIcon)
         }
         
         todayCombiCollectionView.snp.makeConstraints {


### PR DESCRIPTION
## 👀 이슈 번호
<!-- 관련 이슈를 적어주세요 -->
resolve #KAN-13

## ✨ 작업한 내용
- UIButtonConfiguration을 제거하고, UILabel과 UIImageView를 각각 생성한 후, 그 위에 투명한 UIButton을 추가하여 구성.
- 패딩 간격 조절이 버튼의 중앙 정렬 문제로 인해 제대로 동작하지 않아, 텍스트와 아이콘의 위치를 더욱 유연하게 제어할 수 있는 방식으로 수정.


## 🌀 PR Point
<!-- 코드리뷰가 필요한 부분이 있다면 적어주세요 -->


## 📷 스크린샷 또는 GIF
<!-- <img src="" width="30%"> -->


## 🍰 참고사항
<!-- 참고할 사항이 있다면 적어주세요 -->
